### PR TITLE
removing "restrict-directory-view" from rstudio script.sh.erb

### DIFF
--- a/sh_rstudio/template/script.sh.erb
+++ b/sh_rstudio/template/script.sh.erb
@@ -33,7 +33,6 @@ session-timeout-suspend=0
 session-save-action-default=no
 session-quit-child-processes-on-exit=1
 r-restore-workspace=0
-restrict-directory-view=1
 session-default-working-dir=$_workspace_dir
 EOF
 cat <<-EOF > $RSTUDIO_CONFIG_DIR/logging.conf

--- a/sh_rstudio/template/script.sh.erb
+++ b/sh_rstudio/template/script.sh.erb
@@ -10,7 +10,7 @@ module load <%= context.sh_modules %>
 
 # create server configuration
 export RSTUDIO_CONFIG_DIR=$PWD      # system config
-export RSTUDIO_CONFIG_HOME=$PWD     # user config
+export RSTUDIO_CONFIG_HOME="$HOME/.config/rstudio"     # user config
 export RSTUDIO_DATA_HOME=$PWD       # per-session storage
 export RSTUDIO_AUTH="$PWD/bin/auth"
 


### PR DESCRIPTION
Setting `restrict-directory-view=1` seems to prevent opening files from directories other than `$HOME`.